### PR TITLE
[41기 임가림] Add : Payment page 레이아웃 구현

### DIFF
--- a/src/pages/Payment/Payment.jsx
+++ b/src/pages/Payment/Payment.jsx
@@ -1,7 +1,21 @@
 import React from 'react';
+import PaymentAside from './component/PaymentAside/PaymentAside';
+import PaymentInfo from './component/PaymentInfo/PaymentInfo';
+import './Payment.scss';
 
 const Payment = () => {
-  return <div>Payment</div>;
+  return (
+    <div className="payment-wrap">
+      <div className="payment-content">
+        <div className="payment-aside-wrap">
+          <PaymentAside />
+        </div>
+        <div className="payment-info-wrap">
+          <PaymentInfo />
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export default Payment;

--- a/src/pages/Payment/Payment.scss
+++ b/src/pages/Payment/Payment.scss
@@ -10,11 +10,12 @@
 
     .payment-aside-wrap {
       display: flex;
+      position: relative;
       align-items: center;
       justify-content: center;
       width: 40%;
       height: 100%;
-      background-color: black;
+      background-color: #212322;
       color: white;
     }
 

--- a/src/pages/Payment/Payment.scss
+++ b/src/pages/Payment/Payment.scss
@@ -1,0 +1,26 @@
+.payment-wrap {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  height: 1300px;
+
+  .payment-content {
+    display: flex;
+    width: 100%;
+
+    .payment-aside-wrap {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 40%;
+      height: 100%;
+      background-color: black;
+      color: white;
+    }
+
+    .payment-info-wrap {
+      width: 60%;
+      height: 100%;
+    }
+  }
+}

--- a/src/pages/Payment/Payment.scss
+++ b/src/pages/Payment/Payment.scss
@@ -10,7 +10,7 @@
 
     .payment-aside-wrap {
       display: flex;
-      position: relative;
+      // position: relative;
       align-items: center;
       justify-content: center;
       width: 40%;

--- a/src/pages/Payment/Payment.scss
+++ b/src/pages/Payment/Payment.scss
@@ -2,7 +2,7 @@
   display: flex;
   justify-content: center;
   width: 100%;
-  height: 1300px;
+  height: 100%;
 
   .payment-content {
     display: flex;

--- a/src/pages/Payment/Payment.scss
+++ b/src/pages/Payment/Payment.scss
@@ -10,7 +10,6 @@
 
     .payment-aside-wrap {
       display: flex;
-      // position: relative;
       align-items: center;
       justify-content: center;
       width: 40%;

--- a/src/pages/Payment/component/PaymentAside/PaymentAside.jsx
+++ b/src/pages/Payment/component/PaymentAside/PaymentAside.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import './PaymentAside.scss';
+
+const PaymentAside = () => {
+  return (
+    <div>
+      <div className="payment-aside">
+        <h1 className="payment-aside-title">구매 내역</h1>
+        <p>
+          고객님의 주문 내역을 조회해보세요.
+          <br /> 주문 확인 및 취소도 가능합니다.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default PaymentAside;

--- a/src/pages/Payment/component/PaymentAside/PaymentAside.jsx
+++ b/src/pages/Payment/component/PaymentAside/PaymentAside.jsx
@@ -3,13 +3,11 @@ import './PaymentAside.scss';
 
 const PaymentAside = () => {
   return (
-    <div>
-      <div className="payment-aside">
-        <h1 className="payment-aside-title">구매 내역</h1>
-        <p>
-          고객님의 주문 내역을 조회해보세요.
-          <br /> 주문 확인 및 취소도 가능합니다.
-        </p>
+    <div className="payment-aside">
+      <h1 className="payment-aside-title">구매 내역</h1>
+      <div>
+        <p>고객님의 주문 내역을 조회해보세요.</p>
+        <p>주문 확인 및 취소도 가능합니다.</p>
       </div>
     </div>
   );

--- a/src/pages/Payment/component/PaymentAside/PaymentAside.scss
+++ b/src/pages/Payment/component/PaymentAside/PaymentAside.scss
@@ -1,0 +1,15 @@
+.payment-aside {
+  // width: 100%;
+  // background-color: palegreen;
+
+  .payment-aside-title {
+    padding-bottom: 20px;
+    font-size: 35px;
+  }
+
+  p {
+    font-size: 20px;
+    line-height: 30px;
+    // letter-spacing: 5px;
+  }
+}

--- a/src/pages/Payment/component/PaymentAside/PaymentAside.scss
+++ b/src/pages/Payment/component/PaymentAside/PaymentAside.scss
@@ -1,19 +1,16 @@
 .payment-aside {
-  // width: 100%;
-  // background-color: palegreen;
-  position: absolute;
-  top: 40%;
-  left: 30%;
-  // margin: 0 auto;
+  position: fixed;
+  top: 45%;
+  right: 0;
+  left: 10%;
 
   .payment-aside-title {
     padding-bottom: 20px;
-    font-size: 35px;
+    font-size: 25px;
   }
 
   p {
     font-size: 20px;
     line-height: 30px;
-    // letter-spacing: 5px;
   }
 }

--- a/src/pages/Payment/component/PaymentAside/PaymentAside.scss
+++ b/src/pages/Payment/component/PaymentAside/PaymentAside.scss
@@ -1,6 +1,10 @@
 .payment-aside {
   // width: 100%;
   // background-color: palegreen;
+  position: absolute;
+  top: 40%;
+  left: 30%;
+  // margin: 0 auto;
 
   .payment-aside-title {
     padding-bottom: 20px;

--- a/src/pages/Payment/component/PaymentAside/PaymentAside.scss
+++ b/src/pages/Payment/component/PaymentAside/PaymentAside.scss
@@ -1,8 +1,8 @@
 .payment-aside {
-  position: fixed;
-  top: 45%;
-  right: 0;
-  left: 10%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
 
   .payment-aside-title {
     padding-bottom: 20px;

--- a/src/pages/Payment/component/PaymentInfo/PaymentInfo.jsx
+++ b/src/pages/Payment/component/PaymentInfo/PaymentInfo.jsx
@@ -9,9 +9,8 @@ const PaymentInfo = () => {
         <h1 className="product-info-title">구매 내역</h1>
         <PaymentInfoItem />
         <PaymentInfoItem />
-        {/* <PaymentInfoItem />
         <PaymentInfoItem />
-        <PaymentInfoItem /> */}
+        <PaymentInfoItem />
       </div>
     </div>
   );

--- a/src/pages/Payment/component/PaymentInfo/PaymentInfo.jsx
+++ b/src/pages/Payment/component/PaymentInfo/PaymentInfo.jsx
@@ -11,6 +11,7 @@ const PaymentInfo = () => {
         <PaymentInfoItem />
         <PaymentInfoItem />
         <PaymentInfoItem />
+        <PaymentInfoItem />
       </div>
     </div>
   );

--- a/src/pages/Payment/component/PaymentInfo/PaymentInfo.jsx
+++ b/src/pages/Payment/component/PaymentInfo/PaymentInfo.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import PaymentInfoItem from './PaymentInfoItem/PaymentInfoItem';
+import './PaymentInfo.scss';
+
+const PaymentInfo = () => {
+  return (
+    <div>
+      <div className="product-info">
+        <h1 className="product-info-title">Payment History</h1>
+        <PaymentInfoItem />
+        <PaymentInfoItem />
+        <PaymentInfoItem />
+        <PaymentInfoItem />
+      </div>
+    </div>
+  );
+};
+
+export default PaymentInfo;

--- a/src/pages/Payment/component/PaymentInfo/PaymentInfo.jsx
+++ b/src/pages/Payment/component/PaymentInfo/PaymentInfo.jsx
@@ -6,12 +6,12 @@ const PaymentInfo = () => {
   return (
     <div>
       <div className="product-info">
-        <h1 className="product-info-title">Payment History</h1>
+        <h1 className="product-info-title">구매 내역</h1>
         <PaymentInfoItem />
         <PaymentInfoItem />
+        {/* <PaymentInfoItem />
         <PaymentInfoItem />
-        <PaymentInfoItem />
-        <PaymentInfoItem />
+        <PaymentInfoItem /> */}
       </div>
     </div>
   );

--- a/src/pages/Payment/component/PaymentInfo/PaymentInfo.scss
+++ b/src/pages/Payment/component/PaymentInfo/PaymentInfo.scss
@@ -1,12 +1,9 @@
 .product-info {
   height: 1000px;
-  // padding-left: 100px;
-  // background-color: palevioletred;
 
   .product-info-title {
-    padding: 30px;
-    background-color: #212322;
-    color: #fff;
-    font-size: 40px;
+    padding: 30px 30px 40px 30px;
+    background-color: #f5f6f7;
+    font-size: 30px;
   }
 }

--- a/src/pages/Payment/component/PaymentInfo/PaymentInfo.scss
+++ b/src/pages/Payment/component/PaymentInfo/PaymentInfo.scss
@@ -1,0 +1,11 @@
+.product-info {
+  height: 1000px;
+  padding-left: 100px;
+  // background-color: palevioletred;
+
+  .product-info-title {
+    padding: 30px;
+    background-color: palegoldenrod;
+    font-size: 40px;
+  }
+}

--- a/src/pages/Payment/component/PaymentInfo/PaymentInfo.scss
+++ b/src/pages/Payment/component/PaymentInfo/PaymentInfo.scss
@@ -5,7 +5,8 @@
 
   .product-info-title {
     padding: 30px;
-    background-color: palegoldenrod;
+    border-bottom: 4px solid #212322;
+    // background-color: palegoldenrod;
     font-size: 40px;
   }
 }

--- a/src/pages/Payment/component/PaymentInfo/PaymentInfo.scss
+++ b/src/pages/Payment/component/PaymentInfo/PaymentInfo.scss
@@ -1,12 +1,12 @@
 .product-info {
   height: 1000px;
-  padding-left: 100px;
+  // padding-left: 100px;
   // background-color: palevioletred;
 
   .product-info-title {
     padding: 30px;
-    border-bottom: 4px solid #212322;
-    // background-color: palegoldenrod;
+    background-color: #212322;
+    color: #fff;
     font-size: 40px;
   }
 }

--- a/src/pages/Payment/component/PaymentInfo/PaymentInfoItem/PaymentInfoItem.jsx
+++ b/src/pages/Payment/component/PaymentInfo/PaymentInfoItem/PaymentInfoItem.jsx
@@ -3,24 +3,22 @@ import './PaymentInfoItem.scss';
 
 const PaymentInfoItem = () => {
   return (
-    <div>
-      <div className="payment-info-item">
-        <div className="payment-info-data">
-          <p className="payment-info-date">2023-01-06</p>
-          <h1>구매 내역 이름</h1>
-          <p className="payment-info-buy">
-            <span>₩100,000원</span>
-            <span>IWEA 온라인</span>
-          </p>
-          <p className="payment-info-desc">
-            구매가 완료되었습니다. 이용해주셔서 감사합니다.
-            <br />
-            추가 문의사항은 IWEA 고객센터에 문의해주세요.
-          </p>
-        </div>
-        <div className="payment-info-state">
-          <button>결제 취소</button>
-        </div>
+    <div className="payment-info-item">
+      <div className="payment-info-data">
+        <p className="payment-info-date">2023-01-06</p>
+        <h1>구매 내역 이름</h1>
+        <p className="payment-info-buy">
+          <span>₩100,000원</span>
+          <span>IWEA 온라인</span>
+        </p>
+        <p className="payment-info-desc">
+          구매가 완료되었습니다. 이용해주셔서 감사합니다.
+          <br />
+          추가 문의사항은 IWEA 고객센터에 문의해주세요.
+        </p>
+      </div>
+      <div className="payment-info-state">
+        <button>결제 취소</button>
       </div>
     </div>
   );

--- a/src/pages/Payment/component/PaymentInfo/PaymentInfoItem/PaymentInfoItem.jsx
+++ b/src/pages/Payment/component/PaymentInfo/PaymentInfoItem/PaymentInfoItem.jsx
@@ -7,15 +7,19 @@ const PaymentInfoItem = () => {
       <div className="payment-info-item">
         <div className="payment-info-data">
           <p className="payment-info-date">2023-01-06</p>
-          <h1>Iwea 온라인</h1>
-          <p>
-            <span>₩</span>
-            100,000원
+          <h1>구매 내역 이름</h1>
+          <p className="payment-info-buy">
+            <span>₩100,000원</span>
+            <span>IWEA 온라인</span>
           </p>
-          <button>주문 취소</button>
+          <p className="payment-info-desc">
+            구매가 완료되었습니다. 이용해주셔서 감사합니다.
+            <br />
+            추가 문의사항은 IWEA 고객센터에 문의해주세요.
+          </p>
         </div>
         <div className="payment-info-state">
-          <p>결제 취소</p>
+          <button>결제 취소</button>
         </div>
       </div>
     </div>

--- a/src/pages/Payment/component/PaymentInfo/PaymentInfoItem/PaymentInfoItem.jsx
+++ b/src/pages/Payment/component/PaymentInfo/PaymentInfoItem/PaymentInfoItem.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import './PaymentInfoItem.scss';
+
+const PaymentInfoItem = () => {
+  return (
+    <div>
+      <div className="payment-info-item">
+        <div className="payment-info-data">
+          <p className="payment-info-date">2023-01-06</p>
+          <h1>Iwea 온라인</h1>
+          <p>
+            <span>₩</span>
+            100,000원
+          </p>
+          <button>주문 취소</button>
+        </div>
+        <div className="payment-info-state">
+          <p>결제 취소</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PaymentInfoItem;

--- a/src/pages/Payment/component/PaymentInfo/PaymentInfoItem/PaymentInfoItem.scss
+++ b/src/pages/Payment/component/PaymentInfo/PaymentInfoItem/PaymentInfoItem.scss
@@ -5,7 +5,7 @@
   // width: 300px;
   padding: 40px;
   // height: 1000px;
-  border-bottom: 1px solid black;
+  // border-bottom: 1px solid black;
 
   .payment-info-data {
     .payment-info-date {

--- a/src/pages/Payment/component/PaymentInfo/PaymentInfoItem/PaymentInfoItem.scss
+++ b/src/pages/Payment/component/PaymentInfo/PaymentInfoItem/PaymentInfoItem.scss
@@ -1,39 +1,67 @@
 .payment-info-item {
   display: flex;
+  position: relative;
+  z-index: 99;
   align-items: center;
   justify-content: space-between;
-  // width: 300px;
-  padding: 40px;
-  // height: 1000px;
-  // border-bottom: 1px solid #666;
+  padding: 10px 20px 40px 20px;
+  border-bottom: 1px solid #ccc;
 
   .payment-info-data {
+    width: 100%;
+
     .payment-info-date {
-      width: 100%;
-      padding-bottom: 30px;
-      color: #ccc;
-      font-size: 20px;
+      position: absolute;
+      top: -15px;
+      width: 20%;
+      padding: 5px 0;
+      border: 1px solid #ccc;
+      border-radius: 30px;
+      background-color: #fff;
+      font-size: 16px;
+      text-align: center;
     }
 
     h1 {
-      padding-bottom: 10px;
-      font-size: 20px;
+      padding-top: 25px;
+      font-size: 22px;
     }
 
-    p {
-      font-size: 25px;
+    .payment-info-buy {
+      padding: 10px 0 20px 0;
+
+      span:first-child {
+        padding-right: 10px;
+        color: #212322;
+        font-size: 18px;
+      }
+
+      span:last-child {
+        padding-left: 10px;
+        border-left: 1px solid #ccc;
+        color: #5e5e5e;
+      }
     }
 
-    button {
-      padding-top: 10px;
-      border: none;
-      background-color: white;
-      color: #666;
-      cursor: pointer;
+    .payment-info-desc {
+      margin-right: 100px;
+      padding-top: 20px;
+      border-top: 1px solid #ededed;
+      color: #646465;
+      font-size: 14px;
+      line-height: 20px;
     }
   }
 
   .payment-info-state {
-    font-size: 20px;
+    button {
+      width: 90px;
+      padding: 5px;
+      border: 1px solid #ccc;
+      background-color: #f5f6f7;
+      font-size: 20px;
+      font-size: 16px;
+      cursor: pointer;
+    }
   }
 }

--- a/src/pages/Payment/component/PaymentInfo/PaymentInfoItem/PaymentInfoItem.scss
+++ b/src/pages/Payment/component/PaymentInfo/PaymentInfoItem/PaymentInfoItem.scss
@@ -1,0 +1,39 @@
+.payment-info-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  // width: 300px;
+  padding: 40px;
+  // height: 1000px;
+  border-bottom: 1px solid black;
+
+  .payment-info-data {
+    .payment-info-date {
+      width: 100%;
+      padding-bottom: 30px;
+      color: #ccc;
+      font-size: 20px;
+    }
+
+    h1 {
+      padding-bottom: 10px;
+      font-size: 25px;
+    }
+
+    p {
+      font-size: 30px;
+    }
+
+    button {
+      padding-top: 10px;
+      border: none;
+      background-color: white;
+      color: #ccc;
+      cursor: pointer;
+    }
+  }
+
+  .payment-info-state {
+    font-size: 20px;
+  }
+}

--- a/src/pages/Payment/component/PaymentInfo/PaymentInfoItem/PaymentInfoItem.scss
+++ b/src/pages/Payment/component/PaymentInfo/PaymentInfoItem/PaymentInfoItem.scss
@@ -59,7 +59,6 @@
       padding: 5px;
       border: 1px solid #ccc;
       background-color: #f5f6f7;
-      font-size: 20px;
       font-size: 16px;
       cursor: pointer;
     }

--- a/src/pages/Payment/component/PaymentInfo/PaymentInfoItem/PaymentInfoItem.scss
+++ b/src/pages/Payment/component/PaymentInfo/PaymentInfoItem/PaymentInfoItem.scss
@@ -5,7 +5,7 @@
   // width: 300px;
   padding: 40px;
   // height: 1000px;
-  // border-bottom: 1px solid black;
+  // border-bottom: 1px solid #666;
 
   .payment-info-data {
     .payment-info-date {
@@ -17,18 +17,18 @@
 
     h1 {
       padding-bottom: 10px;
-      font-size: 25px;
+      font-size: 20px;
     }
 
     p {
-      font-size: 30px;
+      font-size: 25px;
     }
 
     button {
       padding-top: 10px;
       border: none;
       background-color: white;
-      color: #ccc;
+      color: #666;
       cursor: pointer;
     }
   }

--- a/src/pages/Payment/component/PaymentInfo/PaymentInfoItem/PaymentInfoModal/PaymentInfoModal.jsx
+++ b/src/pages/Payment/component/PaymentInfo/PaymentInfoItem/PaymentInfoModal/PaymentInfoModal.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const PaymentInfoModal = () => {
+  return (
+    <div>
+      <div className="paymentInfoModal"></div>
+    </div>
+  );
+};
+
+export default PaymentInfoModal;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 구매 내역 페이지 레이아웃 제작
- 결제 취소 버튼 클릭 시 결제 취소되는 기능 구현
- 장바구니 페이지에서 구매한 총 금액이 나오도록 통신

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 구매 내역 페이지 레이아웃 제작
- position: fixed;를 이용하여 왼쪽 사이드바 고정
- z-index를 이용하여 구매 날짜가 최상단에 위치하도록 구현

<br />

## :: 성장 포인트
- z-index를 이용하여 원하는 요소를 최상단에 위치하게 하여 원하는 방향으로 구현할 수 있었습니다.

<br />

## :: 기타 질문 및 특이 사항
- 함수 로직이 너무 긴 것 같습니다. 좀 더 효율적인 방법이 없을지 궁금합니다.(예시) 
