### PR TITLE
[41기 김철호] Moidfy: 헤더 마진 0 48px -> 0 5%로 변경

### DIFF
--- a/src/components/Header.scss
+++ b/src/components/Header.scss
@@ -1,7 +1,7 @@
 .header {
   .header-wrap {
-    max-width: 1720px;
-    margin: 0 48px;
+    max-width: 1920px;
+    margin: 0 5%;
     background: #fff;
 
     .logo {
@@ -78,9 +78,9 @@
 
   .nav-wrap {
     box-sizing: border-box;
-    max-width: 1720px;
+    max-width: 1920px;
     height: 100%;
-    margin: 0 48px;
+    margin: 0 5%;
     border-bottom: 1px solid black;
     border-bottom: none;
     background: #fff;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [ ] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [] 컨벤션 수정

<br />


## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

1. home의 전체바디가 width: 90%로 설정되어서 header도 width:90%으로 설정했습니다.

<br />
